### PR TITLE
Set priority key to not null

### DIFF
--- a/internal/pkg/proto/upgrades_registry/upgrades_registry.pb.go
+++ b/internal/pkg/proto/upgrades_registry/upgrades_registry.pb.go
@@ -303,7 +303,7 @@ type Upgrade struct {
 	Step UpgradeStep `protobuf:"varint,7,opt,name=step,proto3,enum=UpgradeStep" json:"step,omitempty" gorm:"default:0;not null"`
 	// priority of the upgrade (highest priority wins)
 	 
-	Priority int32 `protobuf:"varint,8,opt,name=priority,proto3" json:"priority,omitempty" gorm:"primaryKey"`
+	Priority int32 `protobuf:"varint,8,opt,name=priority,proto3" json:"priority,omitempty" gorm:"primaryKey;not null"`
 	// source of the upgrade
 	 
 	Source ProviderType `protobuf:"varint,9,opt,name=source,proto3,enum=ProviderType" json:"source,omitempty" gorm:"not null"`

--- a/internal/pkg/proto/version_resolver/version_resolver.pb.go
+++ b/internal/pkg/proto/version_resolver/version_resolver.pb.go
@@ -40,7 +40,7 @@ type Version struct {
 	Source upgrades_registry.ProviderType `protobuf:"varint,4,opt,name=source,proto3,enum=ProviderType" json:"source,omitempty" gorm:"not null"`
 	// the version priority
 	 
-	Priority int32 `protobuf:"varint,5,opt,name=priority,proto3" json:"priority,omitempty" gorm:"primaryKey"`
+	Priority int32 `protobuf:"varint,5,opt,name=priority,proto3" json:"priority,omitempty" gorm:"primaryKey;not null"`
 }
 
 func (x *Version) Reset() {

--- a/migrations/01_init_tables.psql
+++ b/migrations/01_init_tables.psql
@@ -7,7 +7,7 @@ CREATE TABLE "upgrades"
      "type"        INTEGER NOT NULL,
      "status"      INTEGER NOT NULL DEFAULT 0,
      "step"        INTEGER NOT NULL DEFAULT 0,
-     "priority"    INTEGER,
+     "priority"    INTEGER NOT NULL,
      "source"      INTEGER NOT NULL,
      "proposal_id" BIGINT,
      PRIMARY KEY ("height", "network", "priority")
@@ -19,6 +19,6 @@ CREATE TABLE "versions"
      "network"  TEXT NOT NULL,
      "tag"      TEXT,
      "source"   INTEGER NOT NULL,
-     "priority" INTEGER,
+     "priority" INTEGER NOT NULL,
      PRIMARY KEY ("height", "network", "priority")
   )

--- a/proto/upgrades_registry.proto
+++ b/proto/upgrades_registry.proto
@@ -139,7 +139,7 @@ message Upgrade {
     UpgradeStep step = 7;
 
     // priority of the upgrade (highest priority wins)
-    // @gotags: gorm:"primaryKey"
+    // @gotags: gorm:"primaryKey;not null"
     int32 priority = 8;
 
     // source of the upgrade

--- a/proto/version_resolver.proto
+++ b/proto/version_resolver.proto
@@ -39,7 +39,7 @@ message Version {
    ProviderType source = 4;
 
    // the version priority
-   // @gotags: gorm:"primaryKey"
+   // @gotags: gorm:"primaryKey;not null"
    int32 priority = 5;
 }
 


### PR DESCRIPTION
# TL;DR
The proto field is required by the code, therefore making it `not null` fixes the discrepancy.
Also this is issue on postures primary key due to how it handles DISTINCT and NULL.