### PR TITLE
display network name even if there is no upgrades for blazar instance

### DIFF
--- a/internal/pkg/static/templates/index/index-proxy.html
+++ b/internal/pkg/static/templates/index/index-proxy.html
@@ -117,15 +117,15 @@
                 <th scope="col">{{ $pair.LastUpgrade.Priority }}</th>
                 <th scope="col">{{ $pair.LastUpgrade.Source }}</th>
               {{else}}
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
-                <th scope="col"></th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
+                <th scope="col">{{ $pair.Instance.Network }}</th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
+                <th scope="col">-</th>
               {{end}}
               </tr>
               {{end}}


### PR DESCRIPTION
# TL;DR
When there is no ugprades for instance we still want to display the network name

![image](https://github.com/user-attachments/assets/2515565c-d767-4541-a0ee-7af863788032)
