### PR TITLE
Change upgrade_state metric to upgrade_step

### DIFF
--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -6,7 +6,7 @@ import (
 
 func (d *Daemon) updateMetrics() {
 	// the upgrade state may change, we don't want to persist the metric with the old status
-	d.metrics.State.Reset()
+	d.metrics.Step.Reset()
 	d.metrics.BlocksToUpgrade.Reset()
 
 	upcomingUpgrades := d.ur.GetUpcomingUpgradesWithCache(d.currHeight)
@@ -14,7 +14,7 @@ func (d *Daemon) updateMetrics() {
 		upgradeHeight := strconv.FormatInt(upgrade.Height, 10)
 		status := d.stateMachine.GetStatus(upgrade.Height)
 
-		d.metrics.State.WithLabelValues(upgradeHeight, upgrade.Name, status.String()).Set(float64(d.stateMachine.GetStep(upgrade.Height)))
+		d.metrics.Step.WithLabelValues(upgradeHeight, upgrade.Name, status.String()).Set(float64(d.stateMachine.GetStep(upgrade.Height)))
 		d.metrics.BlocksToUpgrade.WithLabelValues(upgradeHeight, upgrade.Name, status.String()).Set(float64(upgrade.Height - d.currHeight))
 	}
 }

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -15,7 +15,7 @@ const (
 
 type Metrics struct {
 	Up              prometheus.Gauge
-	State           *prometheus.GaugeVec
+	Step            *prometheus.GaugeVec
 	BlocksToUpgrade *prometheus.GaugeVec
 	UpwErrs         prometheus.Counter
 	UiwErrs         prometheus.Counter
@@ -35,11 +35,11 @@ func NewMetrics(composeFile string, hostname string, version string) (*Metrics, 
 				ConstLabels: labels,
 			},
 		),
-		State: promauto.NewGaugeVec(
+		Step: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
-				Name:        "upgrade_state",
-				Help:        "ID of the current stage of the upgrade process",
+				Name:        "upgrade_step",
+				Help:        "ID of the current step of the upgrade process",
 				ConstLabels: labels,
 			},
 			[]string{"upgrade_height", "upgrade_name", "proposal_status"},


### PR DESCRIPTION
The metric exports the current upgrade step, hence it is now named the same