### PR TITLE
Rename proposal_status label to upgrade_status

### DIFF
--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -42,7 +42,7 @@ func NewMetrics(composeFile string, hostname string, version string) (*Metrics, 
 				Help:        "ID of the current step of the upgrade process",
 				ConstLabels: labels,
 			},
-			[]string{"upgrade_height", "upgrade_name", "proposal_status"},
+			[]string{"upgrade_height", "upgrade_name", "upgrade_status"},
 		),
 		BlocksToUpgrade: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -51,7 +51,7 @@ func NewMetrics(composeFile string, hostname string, version string) (*Metrics, 
 				Help:        "Number of blocks to the upgrade height",
 				ConstLabels: labels,
 			},
-			[]string{"upgrade_height", "upgrade_name", "proposal_status"},
+			[]string{"upgrade_height", "upgrade_name", "upgrade_status"},
 		),
 		UpwErrs: promauto.NewCounter(
 			prometheus.CounterOpts{


### PR DESCRIPTION
We populate this label with the result of `d.stateMachine.GetStatus(upgrade.Height)` so naming it `upgrade_status` makes more sense IMO.