### PR TITLE
Don't require container to be down in dcc.Down

### DIFF
--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -472,6 +472,10 @@ func (d *Daemon) performUpgrade(
 		return errors.Wrapf(err, "failed to check if service is running")
 	}
 
+	// This check is prone to race conditions, the image could be up at this point
+	// but exits before dcc.Down is called. However, at this point we are certain
+	// that upgrade height has been hit, so, it should be safe to Down an exited
+	// container.
 	if isRunning {
 		logger.Info("Executing compose down").Notifyf(ctx, "Shutting down chain to perform upgrade. Current image: %s, new image: %s", currImage, newImage)
 		if err = d.dcc.Down(ctx, serviceName, compose.DownTimeout); err != nil {

--- a/internal/pkg/docker/compose_test.go
+++ b/internal/pkg/docker/compose_test.go
@@ -272,23 +272,6 @@ func TestUpDownCompose(t *testing.T) {
 				require.NoError(t, err)
 			},
 		},
-		{
-			name: "simulate case where docker compose up didn't start the container",
-			testFn: func(t *testing.T, _ string) {
-				// step 1: fake docker binary to simulate docker compose up timeout (container isn't running)
-				err = os.WriteFile(filepath.Join(tempDir, "docker"), []byte("#!/bin/sh\nexit 0\n"), 0600)
-				require.NoError(t, err)
-
-				oldPath := os.Getenv("PATH")
-				os.Setenv("PATH", tempDir+":"+oldPath)
-
-				// step 2: with docker compose client try to start container and expect it to fail
-				err = dcc.Down(ctx, "s1", 0)
-				require.ErrorIs(t, err, ErrContainerNotRunning)
-
-				os.Setenv("PATH", oldPath)
-			},
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The check can be racy, let the caller do whatever checks it wants to do. `daemon.go` already has a check where it decides if dcc.Down is needed or not. Now we also add a check to `RestartServiceWithHaltHeight` before it calls Down, with an appropriate error message.

Closes https://github.com/ChorusOne/blazar/issues/25

Not sure how I can add tests for this :(, suggestions welcome!