### PR TITLE
Add validator_address to a few metrics labels

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,10 +34,7 @@ var runCmd = &cobra.Command{
 
 		// setup metrics
 		hostname := util.GetHostname()
-		metrics, err := metrics.NewMetrics(cfg.ComposeFile, hostname, BinVersion)
-		if err != nil {
-			return errors.Wrapf(err, "error creating metrics server")
-		}
+		metrics := metrics.NewMetrics(cfg.ComposeFile, hostname, BinVersion)
 
 		// setup notifier
 		notifier := notification.NewFallbackNotifier(cfg, metrics, lg, hostname)
@@ -56,7 +53,7 @@ var runCmd = &cobra.Command{
 		ctx := notification.WithContextFallback(cmd.Context(), notifier)
 
 		// initialize daemon (fetch initial state and run basic sanity checks)
-		if err := d.Init(ctx, cfg); err != nil {
+		if err := d.Init(ctx, cfg, BinVersion); err != nil {
 			return errors.Wrapf(err, "failed to initialize daemon")
 		}
 

--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 	"blazar/internal/pkg/config"
 	"blazar/internal/pkg/cosmos"
 	"blazar/internal/pkg/daemon/checks"
+	"blazar/internal/pkg/daemon/util"
 	"blazar/internal/pkg/docker"
 	"blazar/internal/pkg/errors"
 	"blazar/internal/pkg/log"
@@ -107,7 +108,7 @@ func NewDaemon(ctx context.Context, cfg *config.Config, m *metrics.Metrics) (*Da
 	}, nil
 }
 
-func (d *Daemon) Init(ctx context.Context, cfg *config.Config) error {
+func (d *Daemon) Init(ctx context.Context, cfg *config.Config, version string) error {
 	logger := log.FromContext(ctx).With("package", "daemon")
 	logger.Info("Starting up blazar daemon...")
 
@@ -130,6 +131,9 @@ func (d *Daemon) Init(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get status response")
 	}
+
+	hostname := util.GetHostname()
+	d.metrics.RegisterValidatorInfoMetrics(cfg.ComposeFile, hostname, version, status.ValidatorInfo.Address.String())
 
 	// display information about the node
 	d.nodeInfo, err = d.cosmosClient.NodeInfo(ctx)


### PR DESCRIPTION
This adds a `validator_address` label which is set to `.valdiator_info.address` from the `/status` tendermint endpoint.
```
blazar_blocks_to_upgrade_height{compose_file="...",hostname="...",upgrade_height="12028945",upgrade_name="testing-for-metrics-2",upgrade_status="ACTIVE",validator_address="CA7978B0C8D1968449053DA54166A8DA6A8DC67E",version="v1.3.0"} 988
...
blazar_upgrade_step{compose_file="...",hostname="...",upgrade_height="12028945",upgrade_name="testing-for-metrics-2",upgrade_status="ACTIVE",validator_address="CA7978B0C8D1968449053DA54166A8DA6A8DC67E",version="v1.3.0"} 1
```
This will be useful in our case to suppress alerts which are identified by the validator address when we know that an upgrade is under progress.