### PR TITLE
Add last_observed_height metric

### DIFF
--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -349,6 +349,7 @@ func (d *Daemon) waitForUpgrade(ctx context.Context, cfg *config.Config) (int64,
 				logger.Err(err).Error("Error received from HeightWatcher")
 				continue
 			}
+			d.metrics.LastObservedHeight.Set(float64(newHeight.Height))
 			currBlockHeight := newHeight.Height
 			lastBlockHeight := d.currHeight
 

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -14,12 +14,13 @@ const (
 )
 
 type Metrics struct {
-	Up              prometheus.Gauge
-	BlocksToUpgrade *prometheus.GaugeVec
-	UpwErrs         prometheus.Counter
-	UiwErrs         prometheus.Counter
-	HwErrs          prometheus.Counter
-	NotifErrs       prometheus.Counter
+	Up                 prometheus.Gauge
+	BlocksToUpgrade    *prometheus.GaugeVec
+	LastObservedHeight prometheus.Gauge
+	UpwErrs            prometheus.Counter
+	UiwErrs            prometheus.Counter
+	HwErrs             prometheus.Counter
+	NotifErrs          prometheus.Counter
 }
 
 func NewMetrics(composeFile, hostname, version string) *Metrics {
@@ -42,6 +43,14 @@ func NewMetrics(composeFile, hostname, version string) *Metrics {
 				ConstLabels: labels,
 			},
 			[]string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address"},
+		),
+		LastObservedHeight: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "last_observed_height",
+				Help:        "Last block height observed by the height watcher",
+				ConstLabels: labels,
+			},
 		),
 		UpwErrs: promauto.NewCounter(
 			prometheus.CounterOpts{


### PR DESCRIPTION
Closes https://github.com/ChorusOne/blazar/issues/30

Exports another metric:
```
# HELP blazar_last_observed_height Last block height observed by the height watcher
# TYPE blazar_last_observed_height gauge
blazar_last_observed_height{compose_file="...",hostname="...",version="devel"} 1.2142927e+07
```