### PR TITLE
Export pre/post check status label in `blazar_blocks_to_upgrade_height`

### DIFF
--- a/internal/pkg/daemon/checks.go
+++ b/internal/pkg/daemon/checks.go
@@ -61,6 +61,7 @@ func (d *Daemon) preUpgradeChecks(
 		// Example: Pre-check failed because network operator didn't register an image tag yet. He'll do it in next 100 blocks,
 		// but if the status is FAILED the operator can't do anyting.
 		d.stateMachine.MustSetStatusAndStep(upgrade.Height, urproto.UpgradeStatus_ACTIVE, urproto.UpgradeStep_PRE_UPGRADE_CHECK)
+		d.updateMetrics()
 	}
 
 	// no need to run checks if none are enabled
@@ -72,6 +73,7 @@ func (d *Daemon) preUpgradeChecks(
 		status := sm.GetPreCheckStatus(upgrade.Height, checksproto.PreCheck_PULL_DOCKER_IMAGE)
 		if status != checksproto.CheckStatus_FINISHED {
 			sm.SetPreCheckStatus(upgrade.Height, checksproto.PreCheck_PULL_DOCKER_IMAGE, checksproto.CheckStatus_RUNNING)
+			d.updateMetrics()
 
 			logger.Infof(
 				"Pre upgrade check: %s Checking if upgrade tag %s is available",
@@ -82,6 +84,7 @@ func (d *Daemon) preUpgradeChecks(
 			d.reportPreUpgradeRoutine(ctx, upgrade, newImage, err)
 
 			sm.SetPreCheckStatus(upgrade.Height, checksproto.PreCheck_PULL_DOCKER_IMAGE, checksproto.CheckStatus_FINISHED)
+			d.updateMetrics()
 		}
 	}
 
@@ -92,6 +95,7 @@ func (d *Daemon) preUpgradeChecks(
 		if shouldRun && status != checksproto.CheckStatus_FINISHED {
 			if upgrade.Type == urproto.UpgradeType_NON_GOVERNANCE_COORDINATED {
 				sm.SetPreCheckStatus(upgrade.Height, checksproto.PreCheck_SET_HALT_HEIGHT, checksproto.CheckStatus_RUNNING)
+				d.updateMetrics()
 
 				logger.Infof(
 					"Pre upgrade step: %s restarting daemon with halt-height %d",
@@ -108,6 +112,7 @@ func (d *Daemon) preUpgradeChecks(
 			}
 
 			sm.SetPreCheckStatus(upgrade.Height, checksproto.PreCheck_SET_HALT_HEIGHT, checksproto.CheckStatus_FINISHED)
+			d.updateMetrics()
 		}
 
 		// When the halt height env was set the node will stop itself at the upgrade height
@@ -201,6 +206,7 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 		// ensure we update the status to failed if any error was encountered
 		if err != nil {
 			d.stateMachine.MustSetStatus(upgradeHeight, urproto.UpgradeStatus_FAILED)
+			d.updateMetrics()
 		}
 	}()
 	ctx = notification.WithUpgradeHeight(ctx, upgradeHeight)
@@ -222,6 +228,7 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 
 	if currStep != urproto.UpgradeStep_POST_UPGRADE_CHECK {
 		d.stateMachine.SetStep(upgradeHeight, urproto.UpgradeStep_POST_UPGRADE_CHECK)
+		d.updateMetrics()
 	}
 
 	// no need to run checks if none are enabled
@@ -233,11 +240,13 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 		status := sm.GetPostCheckStatus(upgradeHeight, checksproto.PostCheck_GRPC_RESPONSIVE)
 		if status != checksproto.CheckStatus_FINISHED {
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_GRPC_RESPONSIVE, checksproto.CheckStatus_RUNNING)
+			d.updateMetrics()
 
 			logger.Infof("Post upgrade check: %s Waiting for the grpc and cometbft services to be responsive", checksproto.PostCheck_GRPC_RESPONSIVE.String()).Notify(ctx)
 
 			_, err = checks.GrpcResponsive(ctx, d.cosmosClient, cfg.GrpcResponsive)
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_GRPC_RESPONSIVE, checksproto.CheckStatus_FINISHED)
+			d.updateMetrics()
 
 			if err != nil {
 				return errors.Wrapf(err, "post upgrade grpc-endpoint-response check failed")
@@ -249,11 +258,13 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 		status := sm.GetPostCheckStatus(upgradeHeight, checksproto.PostCheck_FIRST_BLOCK_VOTED)
 		if status != checksproto.CheckStatus_FINISHED {
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_FIRST_BLOCK_VOTED, checksproto.CheckStatus_RUNNING)
+			d.updateMetrics()
 
 			logger.Infof("Post upgrade check: %s Waiting for the on-chain block at upgrade height=%d to be signed by us", checksproto.PostCheck_FIRST_BLOCK_VOTED.String(), upgradeHeight).Notify(ctx)
 
 			err = checks.NextBlockSignedPostCheck(ctx, d.cosmosClient, cfg.FirstBlockVoted, upgradeHeight)
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_FIRST_BLOCK_VOTED, checksproto.CheckStatus_FINISHED)
+			d.updateMetrics()
 
 			if err != nil {
 				return errors.Wrapf(err, "post upgrade upgrade-block-signed check failed")
@@ -265,6 +276,7 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 		status := sm.GetPostCheckStatus(upgradeHeight, checksproto.PostCheck_CHAIN_HEIGHT_INCREASED)
 		if status != checksproto.CheckStatus_FINISHED {
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_CHAIN_HEIGHT_INCREASED, checksproto.CheckStatus_RUNNING)
+			d.updateMetrics()
 
 			logger.Infof(
 				"Post upgrade check: %s Waiting for the on-chain latest block height to be > upgrade height=%d",
@@ -273,6 +285,7 @@ func (d *Daemon) postUpgradeChecks(ctx context.Context, sm *state_machine.StateM
 
 			err = checks.ChainHeightIncreased(ctx, d.cosmosClient, cfg.ChainHeightIncreased, upgradeHeight)
 			sm.SetPostCheckStatus(upgradeHeight, checksproto.PostCheck_CHAIN_HEIGHT_INCREASED, checksproto.CheckStatus_FINISHED)
+			d.updateMetrics()
 
 			if err != nil {
 				return errors.Wrapf(err, "post upgrade next-block-height check failed")

--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -2,8 +2,34 @@ package daemon
 
 import (
 	checksproto "blazar/internal/pkg/proto/daemon"
+	urproto "blazar/internal/pkg/proto/upgrades_registry"
 	"strconv"
 )
+
+func (d *Daemon) MustSetStatus(height int64, status urproto.UpgradeStatus) {
+	d.stateMachine.MustSetStatus(height, status)
+	d.updateMetrics()
+}
+
+func (d *Daemon) SetStep(height int64, step urproto.UpgradeStep) {
+	d.stateMachine.SetStep(height, step)
+	d.updateMetrics()
+}
+
+func (d *Daemon) MustSetStatusAndStep(height int64, status urproto.UpgradeStatus, step urproto.UpgradeStep) {
+	d.stateMachine.MustSetStatusAndStep(height, status, step)
+	d.updateMetrics()
+}
+
+func (d *Daemon) SetPreCheckStatus(height int64, check checksproto.PreCheck, status checksproto.CheckStatus) {
+	d.stateMachine.SetPreCheckStatus(height, check, status)
+	d.updateMetrics()
+}
+
+func (d *Daemon) SetPostCheckStatus(height int64, check checksproto.PostCheck, status checksproto.CheckStatus) {
+	d.stateMachine.SetPostCheckStatus(height, check, status)
+	d.updateMetrics()
+}
 
 func (d *Daemon) updateMetrics() {
 	// the upgrade state may change, we don't want to persist the metric with the old status

--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	checksproto "blazar/internal/pkg/proto/daemon"
 	"strconv"
 )
 
@@ -13,7 +14,23 @@ func (d *Daemon) updateMetrics() {
 		upgradeHeight := strconv.FormatInt(upgrade.Height, 10)
 		status := d.stateMachine.GetStatus(upgrade.Height)
 
-		d.metrics.BlocksToUpgrade.WithLabelValues(upgradeHeight, upgrade.Name, status.String(),
-			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress).Set(float64(upgrade.Height - d.currHeight))
+		pre_checks_status := make([]string, 0, len(checksproto.PreCheck_value))
+		for _, v := range checksproto.PreCheck_value {
+			pre_checks_status = append(pre_checks_status, d.stateMachine.GetPreCheckStatus(upgrade.Height, checksproto.PreCheck(v)).String())
+		}
+
+		post_checks_status := make([]string, 0, len(checksproto.PreCheck_value))
+		for _, v := range checksproto.PostCheck_value {
+			post_checks_status = append(post_checks_status, d.stateMachine.GetPostCheckStatus(upgrade.Height, checksproto.PostCheck(v)).String())
+		}
+
+		// Merge all label values into a single slice
+		labelValues := append([]string{
+			upgradeHeight, upgrade.Name, status.String(),
+			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress,
+		}, pre_checks_status...)
+		labelValues = append(labelValues, post_checks_status...)
+
+		d.metrics.BlocksToUpgrade.WithLabelValues(labelValues...).Set(float64(upgrade.Height - d.currHeight))
 	}
 }

--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -40,22 +40,22 @@ func (d *Daemon) updateMetrics() {
 		upgradeHeight := strconv.FormatInt(upgrade.Height, 10)
 		status := d.stateMachine.GetStatus(upgrade.Height)
 
-		pre_checks_status := make([]string, 0, len(checksproto.PreCheck_value))
+		preChecksStatus := make([]string, 0, len(checksproto.PreCheck_value))
 		for _, v := range checksproto.PreCheck_value {
-			pre_checks_status = append(pre_checks_status, d.stateMachine.GetPreCheckStatus(upgrade.Height, checksproto.PreCheck(v)).String())
+			preChecksStatus = append(preChecksStatus, d.stateMachine.GetPreCheckStatus(upgrade.Height, checksproto.PreCheck(v)).String())
 		}
 
-		post_checks_status := make([]string, 0, len(checksproto.PreCheck_value))
+		postChecksStatus := make([]string, 0, len(checksproto.PreCheck_value))
 		for _, v := range checksproto.PostCheck_value {
-			post_checks_status = append(post_checks_status, d.stateMachine.GetPostCheckStatus(upgrade.Height, checksproto.PostCheck(v)).String())
+			postChecksStatus = append(postChecksStatus, d.stateMachine.GetPostCheckStatus(upgrade.Height, checksproto.PostCheck(v)).String())
 		}
 
 		// Merge all label values into a single slice
 		labelValues := append([]string{
 			upgradeHeight, upgrade.Name, status.String(),
 			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress,
-		}, pre_checks_status...)
-		labelValues = append(labelValues, post_checks_status...)
+		}, preChecksStatus...)
+		labelValues = append(labelValues, postChecksStatus...)
 
 		d.metrics.BlocksToUpgrade.WithLabelValues(labelValues...).Set(float64(upgrade.Height - d.currHeight))
 	}

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -28,19 +28,19 @@ type Metrics struct {
 func NewMetrics(composeFile, hostname, version string) *Metrics {
 	labels := prometheus.Labels{"hostname": hostname, "compose_file": composeFile, "version": version}
 
-	pre_checks := make([]string, 0, len(checksproto.PreCheck_value))
-	for pc, _ := range checksproto.PreCheck_value {
-		pre_checks = append(pre_checks, pc)
+	preChecks := make([]string, 0, len(checksproto.PreCheck_value))
+	for pc := range checksproto.PreCheck_value {
+		preChecks = append(preChecks, pc)
 	}
 
-	post_checks := make([]string, 0, len(checksproto.PostCheck_value))
-	for pc, _ := range checksproto.PostCheck_value {
-		post_checks = append(post_checks, pc)
+	postChecks := make([]string, 0, len(checksproto.PostCheck_value))
+	for pc := range checksproto.PostCheck_value {
+		postChecks = append(postChecks, pc)
 	}
 
-	blocks_to_upgrade_labels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address"}
-	blocks_to_upgrade_labels = append(blocks_to_upgrade_labels, pre_checks...)
-	blocks_to_upgrade_labels = append(blocks_to_upgrade_labels, post_checks...)
+	blocksToUpgradeLabels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address"}
+	blocksToUpgradeLabels = append(blocksToUpgradeLabels, preChecks...)
+	blocksToUpgradeLabels = append(blocksToUpgradeLabels, postChecks...)
 
 	metrics := &Metrics{
 		Up: promauto.NewGauge(
@@ -58,7 +58,7 @@ func NewMetrics(composeFile, hostname, version string) *Metrics {
 				Help:        "Number of blocks to the upgrade height",
 				ConstLabels: labels,
 			},
-			blocks_to_upgrade_labels,
+			blocksToUpgradeLabels,
 		),
 		LastObservedHeight: promauto.NewGauge(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
Now we have a label for each pre/post check and the value gives the check status.
examples:
```
blazar_blocks_to_upgrade_height{CHAIN_HEIGHT_INCREASED="PENDING",FIRST_BLOCK_VOTED="PENDING",GRPC_RESPONSIVE="PENDING",PULL_DOCKER_IMAGE="FINISHED",SET_HALT_HEIGHT="FINISHED",chain_id="dimension_37-1",compose_file="...",hostname="...",upgrade_height="12943744",upgrade_name="test-metrics",upgrade_status="ACTIVE",upgrade_step="PRE_UPGRADE_CHECK",validator_address="CA7978B0C8D1968449053DA54166A8DA6A8DC67E",version="devel"} 8
```
```
blazar_blocks_to_upgrade_height{CHAIN_HEIGHT_INCREASED="PENDING",FIRST_BLOCK_VOTED="PENDING",GRPC_RESPONSIVE="RUNNING",PULL_DOCKER_IMAGE="FINISHED",SET_HALT_HEIGHT="FINISHED",chain_id="dimension_37-1",compose_file="...",hostname="...",upgrade_height="12943744",upgrade_name="test-metrics",upgrade_status="EXECUTING",upgrade_step="POST_UPGRADE_CHECK",validator_address="CA7978B0C8D1968449053DA54166A8DA6A8DC67E",version="devel"} 0
```