### PR TITLE
Add a timeout to hw to re-create ws subscription

### DIFF
--- a/blazar.sample.toml
+++ b/blazar.sample.toml
@@ -32,11 +32,9 @@ upgrade-info-interval = "300ms"
 # If set to zero (0), Blazar will use a streaming WebSocket client to get the height for every new block
 # Interpreted as Go's time.Duration
 height-interval = "0s"
-# Sometimes the WSS height watcher gets stuck. maybe the chain process restarted
-# and the WS subscription remains hanging with blazar not being able to
-# receive new block heights. In such a case this timeout will be used
-# restart the height-watcher. This parameter is ignored in case of polling
-# based height watcher
+# It happens that WSS height watcher gets stuck. There is a variety of reasons for that (e.g node restarts, network issues, bugs).
+# Blazar can't function properly if it doesn't know the current height of the chain. To ensure the height watcher is always working,
+# the height-timeout parameter is used to restart the height watcher if it doesn't receive a new block height for a given period of time.
 height-timeout = "20s"
 # Interval to poll for upgrade proposals
 # Interpreted as Go's time.Duration

--- a/blazar.sample.toml
+++ b/blazar.sample.toml
@@ -32,6 +32,12 @@ upgrade-info-interval = "300ms"
 # If set to zero (0), Blazar will use a streaming WebSocket client to get the height for every new block
 # Interpreted as Go's time.Duration
 height-interval = "0s"
+# Sometimes the WSS height watcher gets stuck. maybe the chain process restarted
+# and the WS subscription remains hanging with blazar not being able to
+# receive new block heights. In such a case this timeout will be used
+# restart the height-watcher. This parameter is ignored in case of polling
+# based height watcher
+height-timeout = "20s"
 # Interval to poll for upgrade proposals
 # Interpreted as Go's time.Duration
 upgrade-proposals-interval = "10m"

--- a/internal/pkg/chain_watcher/height_watcher.go
+++ b/internal/pkg/chain_watcher/height_watcher.go
@@ -102,7 +102,7 @@ func NewStreamingHeightWatcher(ctx context.Context, cosmosClient *cosmos.Client,
 				logger.Warn("Height watcher has been stuck for too long, checking if chain is stuck")
 				var height int64
 				for {
-					// We will keep retrying until we get a height. THere are too many things that can go wrong so we
+					// We will keep retrying until we get a height. There are too many things that can go wrong so we
 					// return errors to the channel which will make the error metric go up, hence informaing the user
 					// that something is wrong
 					height, err = cosmosClient.GetLatestBlockHeight(ctx)
@@ -126,8 +126,7 @@ func NewStreamingHeightWatcher(ctx context.Context, cosmosClient *cosmos.Client,
 					continue
 				}
 				logger.Warnf("Chain is moving, latest height seen by subscription: %d, latest height seen on chain: %d. Re-creating ws subscription", lastHeight, height)
-				err = cosmosClient.GetCometbftClient().Unsubscribe(ctx, name, query)
-				if err != nil {
+				if err = cosmosClient.GetCometbftClient().Unsubscribe(ctx, name, query); err != nil {
 					logger.Warnf("Failed to unsubscribe from websocket, continuing anyways: %v", err)
 				}
 				for {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -49,6 +49,7 @@ type DockerCredentialHelper struct {
 type Watchers struct {
 	UIInterval time.Duration `toml:"upgrade-info-interval"`
 	HInterval  time.Duration `toml:"height-interval"`
+	HTimeout   time.Duration `toml:"height-timeout"`
 	UPInterval time.Duration `toml:"upgrade-proposals-interval"`
 }
 
@@ -465,6 +466,10 @@ func (cfg *Config) ValidateAll() error {
 
 	if cfg.Watchers.HInterval < 0 {
 		return errors.New("watchers.height-interval cannot be less than 0")
+	}
+
+	if cfg.Watchers.HInterval == 0 && cfg.Watchers.HTimeout <= 0 {
+		return errors.New("watchers.height-timeout cannot be less than or equal to 0 when using ws subscriptions")
 	}
 
 	if cfg.Watchers.UPInterval <= 0 {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -32,6 +32,7 @@ func TestReadConfigToml(t *testing.T) {
 		Watchers: Watchers{
 			UIInterval: 300 * time.Millisecond,
 			HInterval:  0,
+			HTimeout:   20 * time.Second,
 			UPInterval: 10 * time.Minute,
 		},
 		Clients: Clients{

--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -328,7 +328,7 @@ func (d *Daemon) waitForUpgrade(ctx context.Context, cfg *config.Config) (int64,
 	if cfg.Watchers.HInterval > 0 {
 		hw = chain_watcher.NewPeriodicHeightWatcher(ctx, d.cosmosClient, cfg.Watchers.HInterval)
 	} else {
-		hw, err = chain_watcher.NewStreamingHeightWatcher(ctx, d.cosmosClient)
+		hw, err = chain_watcher.NewStreamingHeightWatcher(ctx, d.cosmosClient, cfg.Watchers.HTimeout)
 		if err != nil {
 			return 0, errors.Wrapf(err, "failed to start streaming height watcher")
 		}
@@ -345,7 +345,7 @@ func (d *Daemon) waitForUpgrade(ctx context.Context, cfg *config.Config) (int64,
 		case newHeight := <-hw.Heights:
 			if newHeight.Error != nil {
 				d.metrics.HwErrs.Inc()
-				logger.Err(err).Error("Error received from HeightWatcher")
+				logger.Err(newHeight.Error).Error("Error received from HeightWatcher")
 				continue
 			}
 			d.metrics.LastObservedHeight.Set(float64(newHeight.Height))

--- a/internal/pkg/daemon/daemon_test.go
+++ b/internal/pkg/daemon/daemon_test.go
@@ -525,6 +525,7 @@ func generateConfig(t *testing.T, tempDir, serviceName string, grpcPort, cometbf
 		Watchers: config.Watchers{
 			UIInterval: time.Millisecond * 5,
 			HInterval:  time.Second * 0,
+			HTimeout:   20 * time.Second,
 			UPInterval: time.Minute * 5,
 		},
 		Clients: config.Clients{


### PR DESCRIPTION
We were observing ws subscriptions based height watcher getting stuck. So now we have a timeout in the hw, if the hw doesn't receive a new block within that timeout, the ws subscription will be re-created. In case hw sees errors during that process, they are forwarded to the daemon which is used to bump the hw errors metric, hence informing the user.