### PR TITLE
Metrics: add upgrade_tag to blazar_blocks_to_upgrade_height

### DIFF
--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -53,7 +53,7 @@ func (d *Daemon) updateMetrics() {
 		// Merge all label values into a single slice
 		labelValues := append([]string{
 			upgradeHeight, upgrade.Name, status.String(),
-			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress,
+			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress, upgrade.Tag,
 		}, preChecksStatus...)
 		labelValues = append(labelValues, postChecksStatus...)
 

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -38,7 +38,7 @@ func NewMetrics(composeFile, hostname, version string) *Metrics {
 		postChecks = append(postChecks, pc)
 	}
 
-	blocksToUpgradeLabels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address"}
+	blocksToUpgradeLabels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address", "upgrade_tag"}
 	blocksToUpgradeLabels = append(blocksToUpgradeLabels, preChecks...)
 	blocksToUpgradeLabels = append(blocksToUpgradeLabels, postChecks...)
 


### PR DESCRIPTION
Without setting the upgrade tag:
`blazar_blocks_to_upgrade_height{upgrade_tag=""} 101942`

After setting it:
`blazar_blocks_to_upgrade_height{upgrade_tag="ksawerek"} 101942`

We can alert like so:
```
      - alert: Blazar upgrade tag not set 
        expr: blazar_blocks_to_upgrade_height{upgrade_tag=""} > 0
```
