### PR TITLE
Metrics: add metric for proxy connection error

### DIFF
--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	namespace = "blazar"
+	namespace      = "blazar"
+	proxyNamespace = "blazar_proxy"
 )
 
 type Metrics struct {
@@ -103,6 +104,23 @@ func NewMetrics(composeFile, hostname, version string) *Metrics {
 	}
 
 	return metrics
+}
+
+type ProxyMetrics struct {
+	ConnErrs *prometheus.CounterVec
+}
+
+func NewProxyMetrics() *ProxyMetrics {
+	instanceLabels := []string{"name", "host", "http_port", "grpc_port", "network"}
+	connectionErrors := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: proxyNamespace,
+			Name:      "connection_errors",
+			Help:      "Upgrade proposals watcher error count",
+		},
+		instanceLabels,
+	)
+	return &ProxyMetrics{ConnErrs: connectionErrors}
 }
 
 func RegisterHandler(mux *runtime.ServeMux) error {

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -116,7 +116,7 @@ func NewProxyMetrics() *ProxyMetrics {
 		prometheus.CounterOpts{
 			Namespace: proxyNamespace,
 			Name:      "connection_errors",
-			Help:      "Upgrade proposals watcher error count",
+			Help:      "Proxy connections error count",
 		},
 		instanceLabels,
 	)

--- a/internal/pkg/proxy/config.go
+++ b/internal/pkg/proxy/config.go
@@ -39,7 +39,7 @@ func (cfg *Config) ValidateAll() error {
 			return errors.New("instance name not specified")
 		}
 		if instance.Host == "" {
-			return errors.New("instance hostnot specified")
+			return errors.New("instance host not specified")
 		}
 		if instance.HTTPPort == 0 {
 			return errors.New("instance http port not specified")

--- a/internal/pkg/proxy/index.go
+++ b/internal/pkg/proxy/index.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"blazar/internal/pkg/metrics"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -25,7 +26,7 @@ type instancePair struct {
 	Error       error
 }
 
-func IndexHandler(cfg *Config) http.HandlerFunc {
+func IndexHandler(cfg *Config, proxyMetrics *metrics.ProxyMetrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		mutex := sync.Mutex{}
 		networkUpgrades := make(map[string][]instancePair)
@@ -127,6 +128,8 @@ func IndexHandler(cfg *Config) http.HandlerFunc {
 				}
 
 				if pair.Error != nil {
+					proxyMetrics.ConnErrs.WithLabelValues(pair.Instance.Name,
+						pair.Instance.Host, strconv.Itoa(pair.Instance.GRPCPort), strconv.Itoa(pair.Instance.HTTPPort), pair.Instance.Network).Inc()
 					noErrors++
 				}
 			}

--- a/internal/pkg/proxy/index.go
+++ b/internal/pkg/proxy/index.go
@@ -129,7 +129,7 @@ func IndexHandler(cfg *Config, proxyMetrics *metrics.ProxyMetrics) http.HandlerF
 
 				if pair.Error != nil {
 					proxyMetrics.ConnErrs.WithLabelValues(pair.Instance.Name,
-						pair.Instance.Host, strconv.Itoa(pair.Instance.GRPCPort), strconv.Itoa(pair.Instance.HTTPPort), pair.Instance.Network).Inc()
+						pair.Instance.Host, strconv.Itoa(pair.Instance.HTTPPort), strconv.Itoa(pair.Instance.GRPCPort), pair.Instance.Network).Inc()
 					noErrors++
 				}
 			}

--- a/internal/pkg/proxy/proxy.go
+++ b/internal/pkg/proxy/proxy.go
@@ -3,11 +3,13 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net"
 	"net/http"
 	"strconv"
 
 	"blazar/internal/pkg/log"
+	"blazar/internal/pkg/metrics"
 )
 
 type Proxy struct {
@@ -21,11 +23,20 @@ func (p *Proxy) ListenAndServe(ctx context.Context, cfg *Config) error {
 	logger := log.FromContext(ctx)
 	httpAddr := net.JoinHostPort(cfg.Host, strconv.Itoa(int(cfg.HTTPPort)))
 
+	mux := http.NewServeMux()
+
 	// register handlers
-	http.HandleFunc("/", IndexHandler(cfg))
+	proxyMetrics := metrics.NewProxyMetrics()
+	mux.HandleFunc("/", IndexHandler(cfg, proxyMetrics))
+	mux.Handle("/metrics", promhttp.Handler())
+
+	server := &http.Server{
+		Addr:    httpAddr,
+		Handler: mux,
+	}
 
 	logger.Infof("serving http server on %s", httpAddr)
-	if err := http.ListenAndServe(httpAddr, nil); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		fmt.Println("error serving http server", err)
 		panic(err)
 	}

--- a/internal/pkg/proxy/proxy.go
+++ b/internal/pkg/proxy/proxy.go
@@ -3,13 +3,14 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net"
 	"net/http"
 	"strconv"
 
 	"blazar/internal/pkg/log"
 	"blazar/internal/pkg/metrics"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Proxy struct {


### PR DESCRIPTION
Example metric (changed the http port to force errors):
```
blazar_proxy_connection_errors{grpc_port="5931",host="100.91.49.79",http_port="5931",name="validator135",network="lombard_testnet"} 4
```
we can alert on increase