### PR TITLE
fix zero height check

### DIFF
--- a/internal/pkg/chain_watcher/height_watcher.go
+++ b/internal/pkg/chain_watcher/height_watcher.go
@@ -151,11 +151,11 @@ func NewStreamingHeightWatcher(ctx context.Context, cosmosClient *cosmos.Client,
 
 			case tx := <-txs:
 				if data, ok := tx.Data.(ctypes.EventDataNewBlock); ok {
-					height := data.Block.Header.Height
-					logger.Debugf("Height watcher observed new height: %d", height)
+					lastHeight = data.Block.Header.Height
+					logger.Debugf("Height watcher observed new height: %d", lastHeight)
 					select {
 					case heights <- NewHeight{
-						Height: height,
+						Height: lastHeight,
 						Error:  nil,
 					}:
 					// prevents deadlock with heights channel


### PR DESCRIPTION
# TL;DR
This is the info message, and 0 is invalid value because apparently we never update `lastHeight`
```
Chain is moving, latest height seen by subscription: 0, latest height seen on chain: 16912345. Re-creating ws subscription
```