### PR TITLE
Skip warning emoji

### DIFF
--- a/internal/pkg/static/templates/index/index-blazar.html
+++ b/internal/pkg/static/templates/index/index-blazar.html
@@ -413,8 +413,10 @@
                           data-height="{{ .Height }}"
                           data-tooltip="Click to add the version tag at this height"
                           onclick="handleButtonAddUpgrade(this)">➕
-                  </button>                {{ else }}
-                <div style="border-bottom: none; color: #ff9500" data-tooltip="Upgrade has been skipped due to lack of version tag">⚠ </div>
+                  </button>
+                <!-- status 5 is failed, see upgrades_registry.proto -->
+                {{ else if eq $element.Status 5 }}
+                <div style="border-bottom: none; color: #ff9500" data-tooltip="Upgrade failed">⚠ </div>
                 {{ end }}
                 </th>
                 <th scope="col">{{ $element.Network }}</th>

--- a/internal/pkg/static/templates/index/index-proxy.html
+++ b/internal/pkg/static/templates/index/index-proxy.html
@@ -105,7 +105,8 @@
                 <th scope="col">
                 {{ if $pair.LastUpgrade.Tag }}
                 {{ $pair.LastUpgrade.Tag }}
-                {{ else }}
+                <!-- status 6 is expired, status 7 is cancelled, see upgrades_registry.proto -->
+                {{ else if and (ne $pair.LastUpgrade.Status 6) (ne $pair.LastUpgrade.Status 7) }}
                 <div style="border-bottom: none; color: #ff9500" data-tooltip="Without version tag Blazar will ignore the upgrade">⚠ </div>
                 {{ end }}
                 </th>


### PR DESCRIPTION
### Details
On blazar index page, only shows the warning icon if upgrade failed. On blazar proxy, shows it if there's no tag and the upgrade is neither expired nor canceled. This also led me to think that we could try to add the + button to proxy, make it redirect to an already open form. This would require a bit more changes though.  

Closes https://github.com/ChorusOne/blazar/issues/47