### PR TITLE
Proxy: poll instances in the background

### DIFF
--- a/internal/pkg/proxy/config.go
+++ b/internal/pkg/proxy/config.go
@@ -37,7 +37,7 @@ func (cfg *Config) ValidateAll() error {
 		return errors.New("no instances specified")
 	}
 	if cfg.PollInterval <= time.Duration(0) {
-		return errors.New(fmt.Sprintf("poll interval not specified or invalid value, got value: %s", cfg.PollInterval))
+		return fmt.Errorf("poll interval not specified or invalid value, got value: %s", cfg.PollInterval)
 	}
 	if cfg.Host == "" {
 		return errors.New("listen host not specified")

--- a/internal/pkg/proxy/config.go
+++ b/internal/pkg/proxy/config.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"blazar/internal/pkg/errors"
+	"fmt"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -15,9 +17,10 @@ type Instance struct {
 }
 
 type Config struct {
-	Host      string     `toml:"host"`
-	HTTPPort  uint16     `toml:"http-port"`
-	Instances []Instance `toml:"instance"`
+	Host         string        `toml:"host"`
+	HTTPPort     uint16        `toml:"http-port"`
+	PollInterval time.Duration `toml:"poll-interval"`
+	Instances    []Instance    `toml:"instance"`
 }
 
 func ReadConfig(cfgFile string) (*Config, error) {
@@ -32,6 +35,15 @@ func ReadConfig(cfgFile string) (*Config, error) {
 func (cfg *Config) ValidateAll() error {
 	if len(cfg.Instances) == 0 {
 		return errors.New("no instances specified")
+	}
+	if cfg.PollInterval <= time.Duration(0) {
+		return errors.New(fmt.Sprintf("poll interval not specified or invalid value, got value: %s", cfg.PollInterval))
+	}
+	if cfg.Host == "" {
+		return errors.New("listen host not specified")
+	}
+	if cfg.HTTPPort == 0 {
+		return errors.New("listen port not specified")
 	}
 
 	for _, instance := range cfg.Instances {

--- a/internal/pkg/proxy/index.go
+++ b/internal/pkg/proxy/index.go
@@ -28,9 +28,8 @@ type instancePair struct {
 
 func IndexHandler(cfg *Config, proxyMetrics *metrics.ProxyMetrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		start := time.Now()
-		networkUpgrades := CheckInstances(r.Context(), cfg, proxyMetrics)
+		networkUpgrades := checkInstances(r.Context(), cfg, proxyMetrics)
 		end := time.Now()
 
 		noInstances, noActive, noExecuting, noExpired, noCompleted, noErrors := uint(0), uint(0), uint(0), uint(0), uint(0), uint(0)
@@ -118,7 +117,7 @@ func IndexHandler(cfg *Config, proxyMetrics *metrics.ProxyMetrics) http.HandlerF
 	}
 }
 
-func CheckInstances(_ context.Context, cfg *Config, proxyMetrics *metrics.ProxyMetrics) map[string][]instancePair {
+func checkInstances(_ context.Context, cfg *Config, proxyMetrics *metrics.ProxyMetrics) map[string][]instancePair {
 	var (
 		mutex           sync.Mutex
 		networkUpgrades = make(map[string][]instancePair)

--- a/internal/pkg/proxy/proxy.go
+++ b/internal/pkg/proxy/proxy.go
@@ -41,7 +41,7 @@ func (p *Proxy) ListenAndServe(ctx context.Context, cfg *Config) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				CheckInstances(ctx, cfg, proxyMetrics)
+				checkInstances(ctx, cfg, proxyMetrics)
 			}
 		}
 	}()


### PR DESCRIPTION
### Details

We've added connection error metrics in https://github.com/ChorusOne/blazar/pull/39, but those do not update unless there's a visit to the index page. Added background polling with configurable interval to fix that. Also added validation for proxy listen host and port, but maybe that's not desired, please let me know if that is indeed the case. 

### Test plan

Ran it with a range wide of hosts, and the index page looks and acts the same as the current main branch. The metrics also increment with the interval, so works as expected. 