### PR TITLE
Add chain ID to config and export it as a label

### DIFF
--- a/blazar.sample.toml
+++ b/blazar.sample.toml
@@ -13,6 +13,9 @@ upgrade-mode = "compose-file"
 
 # Absolute path to the chain home directory on the host system
 chain-home = "<path>"
+# Chain ID reported by the Status endpoint
+chain-id = "<chain_id>"
+
 # Info log level (0 for debug, -1 for trace)
 # Refer to https://pkg.go.dev/github.com/rs/zerolog#readme-leveled-logging for all options
 log-level = 1

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,7 @@ var runCmd = &cobra.Command{
 
 		// setup metrics
 		hostname := util.GetHostname()
-		metrics := metrics.NewMetrics(cfg.ComposeFile, hostname, BinVersion)
+		metrics := metrics.NewMetrics(cfg.ComposeFile, hostname, BinVersion, cfg.ChainID)
 
 		// setup notifier
 		notifier := notification.NewFallbackNotifier(cfg, metrics, lg, hostname)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -171,6 +171,7 @@ type Config struct {
 	Host             string                  `toml:"host"`
 	GrpcPort         uint16                  `toml:"grpc-port"`
 	HTTPPort         uint16                  `toml:"http-port"`
+	ChainID          string                  `toml:"chain-id"`
 	Watchers         Watchers                `toml:"watchers"`
 	Clients          Clients                 `toml:"clients"`
 	Compose          ComposeCli              `toml:"compose-cli"`
@@ -446,6 +447,10 @@ func (cfg *Config) ValidateAll() error {
 
 	if err := cfg.ValidateChainHome(); err != nil {
 		return err
+	}
+
+	if cfg.ChainID == "" {
+		return errors.New("chain-id cannot be empty")
 	}
 
 	if cfg.LogLevel < -1 || cfg.LogLevel > 7 {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -25,6 +25,7 @@ func TestReadConfigToml(t *testing.T) {
 		ComposeService: "<service>",
 		UpgradeMode:    UpgradeInComposeFile,
 		ChainHome:      "<path>",
+		ChainID:        "<chain_id>",
 		LogLevel:       1,
 		Host:           "0.0.0.0",
 		HTTPPort:       1234,

--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -136,6 +136,10 @@ func (d *Daemon) Init(ctx context.Context, cfg *config.Config) error {
 		return errors.Wrapf(err, "failed to get status response")
 	}
 
+	if status.NodeInfo.Network != cfg.ChainID {
+		return fmt.Errorf("chain ID mismatch, expected: %s, got: %s", cfg.ChainID, status.NodeInfo.Network)
+	}
+
 	d.chainID = status.NodeInfo.Network
 	d.validatorAddress = status.ValidatorInfo.Address
 

--- a/internal/pkg/daemon/daemon_test.go
+++ b/internal/pkg/daemon/daemon_test.go
@@ -75,7 +75,7 @@ func TestIntegrationDaemon(t *testing.T) {
 	}()
 
 	// we can't register 2 metrics, but this sharing this should probably cause no problems
-	metrics := metrics.NewMetrics("/path/to/docker-compose.yml", "dummy", "test", "")
+	metrics := metrics.NewMetrics("/path/to/docker-compose.yml", "dummy", "test", "chain-id")
 
 	ports := getFreePorts(t, 6)
 

--- a/internal/pkg/daemon/daemon_test.go
+++ b/internal/pkg/daemon/daemon_test.go
@@ -75,7 +75,7 @@ func TestIntegrationDaemon(t *testing.T) {
 	}()
 
 	// we can't register 2 metrics, but this sharing this should probably cause no problems
-	metrics := metrics.NewMetrics("/path/to/docker-compose.yml", "dummy", "test")
+	metrics := metrics.NewMetrics("/path/to/docker-compose.yml", "dummy", "test", "")
 
 	ports := getFreePorts(t, 6)
 

--- a/internal/pkg/daemon/metrics.go
+++ b/internal/pkg/daemon/metrics.go
@@ -53,7 +53,7 @@ func (d *Daemon) updateMetrics() {
 		// Merge all label values into a single slice
 		labelValues := append([]string{
 			upgradeHeight, upgrade.Name, status.String(),
-			d.stateMachine.GetStep(upgrade.Height).String(), d.chainID, d.validatorAddress, upgrade.Tag,
+			d.stateMachine.GetStep(upgrade.Height).String(), d.validatorAddress, upgrade.Tag,
 		}, preChecksStatus...)
 		labelValues = append(labelValues, postChecksStatus...)
 

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -26,8 +26,8 @@ type Metrics struct {
 	NotifErrs          prometheus.Counter
 }
 
-func NewMetrics(composeFile, hostname, version string) *Metrics {
-	labels := prometheus.Labels{"hostname": hostname, "compose_file": composeFile, "version": version}
+func NewMetrics(composeFile, hostname, version, chainID string) *Metrics {
+	labels := prometheus.Labels{"hostname": hostname, "compose_file": composeFile, "version": version, "chain_id": chainID}
 
 	preChecks := make([]string, 0, len(checksproto.PreCheck_value))
 	for pc := range checksproto.PreCheck_value {
@@ -39,7 +39,7 @@ func NewMetrics(composeFile, hostname, version string) *Metrics {
 		postChecks = append(postChecks, pc)
 	}
 
-	blocksToUpgradeLabels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "chain_id", "validator_address", "upgrade_tag"}
+	blocksToUpgradeLabels := []string{"upgrade_height", "upgrade_name", "upgrade_status", "upgrade_step", "validator_address", "upgrade_tag"}
 	blocksToUpgradeLabels = append(blocksToUpgradeLabels, preChecks...)
 	blocksToUpgradeLabels = append(blocksToUpgradeLabels, postChecks...)
 


### PR DESCRIPTION
### Details
Adds chain ID to config, to help export it as a label. Also adds a sanity check to see if the chain ID we got from Status call matches what's set in the config

### Test plan 
When running with some dummy value for chain ID:
```
7:53PM INF Attempting to get data from /status endpoint with Cosmos RPC client module=blazar package=daemon
Error: failed to initialize daemon: chain ID mismatch, expected: asd, got: deluge-1
Usage:
  blazar run [flags]
```

Otherwise, an example metric:
```
blazar_up{chain_id="deluge-1",compose_file="path-to-docker-compose.yml",hostname="<my-pc-hostname>",version="unknown"} 1
```

### Links
Closes #52 
  