### PR TITLE
add reading version at blazar startup

### DIFF
--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -557,6 +557,10 @@ func validateComposeSettings(cfg *config.Config) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse docker compose file")
 	}
+	_, err = docker.LoadServiceVersionFile(cfg.VersionFile, cfg.ComposeService)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get service versions from compose file")
+	}
 
 	if slices.Contains(cfg.Checks.PreUpgrade.Enabled, checksproto.PreCheck_SET_HALT_HEIGHT.String()) {
 		prefix := cfg.Compose.EnvPrefix + "HALT_HEIGHT"


### PR DESCRIPTION
## Details
Check at startup to see if `VERSION_service` env variable is defined. Fails fast if not. 
Didn't do it as a pre-check, it might be too late to check for it while the upgrade is undergoing.

Tested with 
```
➜  blazar git:(dotenvfile-check-at-startup) ./blazar run --config blazar.toml
WARN[0000] The "HALT_HEIGHT" variable is not set. Defaulting to a blank string.
12:06PM INF Starting up blazar daemon... module=blazar package=daemon
12:06PM INF Setting up docker and docker compose clients module=blazar package=daemon
12:06PM INF Attempting to get data from /status endpoint with Cosmos RPC client module=blazar package=daemon
12:06PM INF Using env prefix: GAIA_ module=blazar package=daemon
WARN[0002] The "HALT_HEIGHT" variable is not set. Defaulting to a blank string.
Error: failed to initialize daemon: failed to validate docker compose settings: failed to get service versions from compose file: could not find VERSION_gaia on /Users/pyoxa/trash/dummy-for-blazar/.env
Usage:
  blazar run [flags]

Flags:
  -h, --help   help for run

Global Flags:
      --config string   config toml file
```

## Links
Closes #51 
