### PR TITLE
fix blazar night mode color

### DIFF
--- a/internal/pkg/static/templates/index/index-blazar.html
+++ b/internal/pkg/static/templates/index/index-blazar.html
@@ -256,7 +256,7 @@
           {{ if .Warning }}
           <p><mark>{{ .Warning }}</mark></p>
           {{ else }}
-          <p><mark id="blazar_status_mark" style="background-color: #9bcffd">Blazar is synchronized! Now you should see the list of registered upgrades observed by this blazar instance.</mark></p>
+          <p><mark id="blazar_status_mark" style="background-color: var(--pico-text-selection-color)">Blazar is synchronized! Now you should see the list of registered upgrades observed by this blazar instance.</mark></p>
           {{ end }}
         </section>
       </div>

--- a/internal/pkg/static/templates/index/index-proxy.html
+++ b/internal/pkg/static/templates/index/index-proxy.html
@@ -61,7 +61,7 @@
           {{ if .Warning }}
           <p><mark>{{ .Warning }}</mark></p>
           {{ else }}
-          <p><mark id="blazar_status_mark" style="background-color: #9bcffd">Blazar Proxy is now synchronized! Now you should see the aggregate list of the latest upgrades from each instance</mark></p>
+          <p><mark id="blazar_status_mark" style="background-color: var(--pico-text-selection-color)">Blazar Proxy is now synchronized! Now you should see the aggregate list of the latest upgrades from each instance</mark></p>
           {{ end }}
         </section>
       </div>


### PR DESCRIPTION
By using the pico class the night mode colors are automatically switched.

In light mode it looks like this:
<img width="903" height="32" alt="image" src="https://github.com/user-attachments/assets/9a11dd3a-9c9a-4967-87be-ba1472c9e409" />

so not much difference, but works much better in dark mode