### PR TITLE
Make status badges in UI more readable

### DIFF
--- a/internal/pkg/static/templates/index/index-blazar.html
+++ b/internal/pkg/static/templates/index/index-blazar.html
@@ -209,22 +209,35 @@
         --pico-font-size: 90%;
       }
 
-      .badge {
-          display: inline-flex;
-          align-items: center;
-          background-color: #525252;
-          border-radius: 3px;
-          color: white;
-          padding: 5px 10px;
-          margin-bottom: 1px;
-          font-size: var(--pico-font-size);
+      .stats-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        margin-top: 1.5rem;
       }
 
-      .badge .count {
-          background-color: #409614;
-          padding: 2px 6px;
-          border-radius: 3px;
-          margin-left: 5px;
+      .stat-card {
+        background: var(--pico-card-background-color);
+        border: 1px solid var(--pico-muted-border-color);
+        border-radius: 8px;
+        padding: 1rem;
+      }
+
+      .stat-label {
+        font-size: 0.875rem;
+        color: var(--pico-color);
+        margin-bottom: 0.25rem;
+      }
+
+      .stat-value {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--pico-color);
+      }
+
+      .stat-card-button {
+        border-radius: 8px;
+        background: var(--pico-card-background-color);
       }
     </style>
   </head>
@@ -242,16 +255,29 @@
           <p>Automatic node upgrades for Cosmos SDK networks</p>
         </hgroup>
         <section id="">
-          <p>
-              <div class="badge"><span>Network</span><span class="count">{{ .DefaultNetwork }}</span></div>
-              <div class="badge"><span>Current Height</span><span class="count">{{ .CurrentBlockHeight }}</span></div>
-              <div class="badge"><span>Last Update</span><span class="count">{{ .LastUpdateTime }} ({{ .LastUpdateDiff }} ago)</span></div>
-              <div class="badge"><span>Avg Block Speed</span><span class="count">{{ .BlockSpeed }}s</span></div>
-              <div class="badge"><span>Time to next sync</span><span class="count">{{ .SecondsToNextUpdate }}s</span></div>
-              <div class="badge" style="background-color: var(--pico-primary-background)">
-                  <a href="#" id="force_sync" style="color: white; padding: 2px 6px" data-tooltip="Send a request to force sync the state">Force Sync</a>
-              </div>
-          </p>
+          <div class="stats-grid">
+            <div class="stat-card">
+              <div class="stat-label">Network</div>
+              <div class="stat-value">{{ .DefaultNetwork }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Current Height</div>
+              <div class="stat-value">{{ .CurrentBlockHeight }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Last Update</div>
+              <div class="stat-value">{{ .LastUpdateDiff }} ago</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Avg Block Time</div>
+              <div class="stat-value">{{ .BlockSpeed }}s</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Next Sync</div>
+              <div class="stat-value">{{ .SecondsToNextUpdate }}s</div>
+            </div>
+            <button class="stat-card-button outline" id="force_sync" data-tooltip="Send a request to force sync the state">Sync now</button>
+          </div>
           <hr />
           {{ if .Warning }}
           <p><mark>{{ .Warning }}</mark></p>

--- a/internal/pkg/static/templates/index/index-proxy.html
+++ b/internal/pkg/static/templates/index/index-proxy.html
@@ -15,22 +15,35 @@
         --pico-font-size: 90%;
       }
 
-      .badge {
-          display: inline-flex;
-          align-items: center;
-          background-color: #525252;
-          border-radius: 3px;
-          color: white;
-          padding: 5px 10px;
-          margin-bottom: 1px;
-          font-size: var(--pico-font-size);
+      .stats-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        margin-top: 1.5rem;
       }
 
-      .badge .count {
-          background-color: #409614;
-          padding: 2px 6px;
-          border-radius: 3px;
-          margin-left: 5px;
+      .stat-card {
+        background: var(--pico-card-background-color);
+        border: 1px solid var(--pico-muted-border-color);
+        border-radius: 8px;
+        padding: 1rem;
+      }
+
+      .stat-label {
+        font-size: 0.875rem;
+        color: var(--pico-color);
+        margin-bottom: 0.25rem;
+      }
+
+      .stat-value {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--pico-color);
+      }
+
+      .stat-card-button {
+        border-radius: 8px;
+        background: var(--pico-card-background-color);
       }
     </style>
   </head>
@@ -47,16 +60,40 @@
           <p>Aggregate information about Blazar instances</p>
         </hgroup>
         <section id="">
-          <p>
-              <div class="badge"><span>Networks</span><span class="count">{{ .NoNetworks }}</span></div>
-              <div class="badge"><span>Instances</span><span class="count">{{ .NoInstances }}</span></div>
-              <div class="badge"><span>Errors</span><span class="count">{{ .NoErrors }}</span></div>
-              <div class="badge"><span>Active</span><span class="count">{{ .NoActive }}</span></div>
-              <div class="badge"><span>Executing</span><span class="count">{{ .NoExecuting }}</span></div>
-              <div class="badge"><span>Expired</span><span class="count">{{ .NoExpired }}</span></div>
-              <div class="badge"><span>Completed</span><span class="count">{{ .NoCompleted }}</span></div>
-              <div class="badge"><span>Fetch Time</span><span class="count">{{ .FetchTime }}</span></div>
-          </p>
+          <div class="stats-grid">
+            <div class="stat-card">
+              <div class="stat-label">Networks</div>
+              <div class="stat-value">{{ .NoNetworks }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Instances</div>
+              <div class="stat-value">{{ .NoInstances }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Errors</div>
+              <div class="stat-value">{{ .NoErrors }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Active</div>
+              <div class="stat-value">{{ .NoActive }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Executing</div>
+              <div class="stat-value">{{ .NoExecuting }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Expired</div>
+              <div class="stat-value">{{ .NoExpired }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Completed</div>
+              <div class="stat-value">{{ .NoCompleted }}</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-label">Fetch Time</div>
+              <div class="stat-value">{{ .FetchTime }}</div>
+            </div>
+          </div>
           <hr />
           {{ if .Warning }}
           <p><mark>{{ .Warning }}</mark></p>


### PR DESCRIPTION
Updated the badges a bit. It's not the greatest in the world, but we start small.

Also comes with minor patches:
- "Avg Block Speed" -> "Avg Block Time", to be unambiguous
- "Force sync" -> "Sync now", to reflect the reality
- "Time to next sync" -> "Next sync", just shorter

blazar:
<img width="1977" height="347" alt="image" src="https://github.com/user-attachments/assets/33d0cddd-39df-4d5a-9443-6b01c19c6572" />

blazar proxy:
<img width="1977" height="347" alt="image" src="https://github.com/user-attachments/assets/7c9492b9-9a4f-41ca-9969-d399a281af65" />
