### PR TITLE
ci: Set Docker API version explicitly

### DIFF
--- a/.github/workflows/blazar.yml
+++ b/.github/workflows/blazar.yml
@@ -30,6 +30,8 @@ jobs:
           go-version: '1.22.8'
 
       - name: Build and test
+        env:
+          DOCKER_API_VERSION: "1.41"
         run: |
           make test
 


### PR DESCRIPTION
Apparently Docker Engine v29 broke some compatibility with testcontainers, but setting this var should work.