### PR TITLE
Show block time with only 3 decimals places

### DIFF
--- a/internal/pkg/daemon/index.go
+++ b/internal/pkg/daemon/index.go
@@ -104,7 +104,7 @@ func RegisterIndexHandler(mux *runtime.ServeMux, d *Daemon, upInterval time.Dura
 			SecondsToNextUpdate int64
 			LastBlockHeight     int64
 			CurrentBlockHeight  int64
-			BlockSpeed          float64
+			AvgBlockTime        string
 			Upgrades            []*urproto.Upgrade
 			BlocksToUpgrade     map[int64]string
 			BlocksToETA         map[int64]string
@@ -121,7 +121,7 @@ func RegisterIndexHandler(mux *runtime.ServeMux, d *Daemon, upInterval time.Dura
 			SecondsToNextUpdate: int64(time.Until(syncInfo.LastUpdateTime.Add(upInterval)).Seconds()),
 			LastBlockHeight:     syncInfo.LastBlockHeight,
 			CurrentBlockHeight:  latestHeight,
-			BlockSpeed:          blockSpeed.Seconds(),
+			AvgBlockTime:        fmt.Sprintf("%.3fs", blockSpeed.Seconds()),
 			Upgrades:            upgrades,
 			BlocksToUpgrade:     blocksToUpgradeMap,
 			BlocksToETA:         blocksToETAMap,

--- a/internal/pkg/static/templates/index/index-blazar.html
+++ b/internal/pkg/static/templates/index/index-blazar.html
@@ -270,7 +270,7 @@
             </div>
             <div class="stat-card">
               <div class="stat-label">Avg Block Time</div>
-              <div class="stat-value">{{ .BlockSpeed }}s</div>
+              <div class="stat-value">{{ .AvgBlockTime }}</div>
             </div>
             <div class="stat-card">
               <div class="stat-label">Next Sync</div>


### PR DESCRIPTION
To prevent incidental stretches of the UI.

before (sometimes)

<img width="1977" height="309" alt="image" src="https://github.com/user-attachments/assets/3f7e88fa-ece9-48a1-8f16-f8b2bb881f23" />

after

<img width="1977" height="309" alt="image" src="https://github.com/user-attachments/assets/9f4c0e82-034d-4819-bf4c-7e426d70e2d6" />
