### PR TITLE
Decode the response as untyped JSON

### DIFF
--- a/internal/pkg/daemon/checks/post.go
+++ b/internal/pkg/daemon/checks/post.go
@@ -230,12 +230,16 @@ func NextBlockSignedPostCheck(ctx context.Context, cosmosClient *cosmos.Client, 
 	notifTicker := time.NewTicker(postUpgradeChecks.NotifInterval)
 	timeout := time.NewTimer(postUpgradeChecks.Timeout)
 
-	status, err := cosmosClient.GetCometbftClient().Status(ctx)
+	status, err := cosmosClient.GetStatus(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get node status")
 	}
 
-	nodeAddress := status.ValidatorInfo.Address
+	nodeAddressBytes, err := hex.DecodeString(status.ValidatorInfo.Address)
+	if err != nil {
+		return errors.Wrapf(err, "Could not parse node address %q", status.ValidatorInfo.Address)
+	}
+	nodeAddress := bytes.HexBytes(nodeAddressBytes)
 	logger.Infof("Post upgrade check 2: Waiting to sign the first block after upgrade=%d, address=%s", upgradeHeight, nodeAddress.String()).Notify(ctx)
 	if status.ValidatorInfo.VotingPower == 0 {
 		logger.Info("Post upgrade check 2: skipping signature check, as VP is 0").Notify(ctx)


### PR DESCRIPTION
The `cometbftClient.Status()` tries to decode the response with some hardcoded tags, which don't include the one used by Polygon Heimdall (v2), and therefore making Blazar fail on the post upgrade check:

```
Post-upgrade check failed

error: post upgrade upgrade-block-signed check failed: Could not get
node status: error in json rpc client, with http response metadata:
(Status: 200 OK, Protocol HTTP/1.1). error unmarshalling result:
unknown type "cometbft/PubKeySecp256k1eth"
```

This patch avoids matching the type, as we don't really need it.