### PR TITLE
Fix block time calculation

### DIFF
--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -529,17 +529,17 @@ func (d *Daemon) performUpgrade(
 }
 
 func (d *Daemon) updateHeightAndBlockSpeed(newHeight int64) {
-	// calculate block speed based on the last few observed blocks
+	if d.currHeight == newHeight {
+		return
+	}
+
 	lastBlockHeight := d.currHeight
 	lastHeightTime := d.currHeightTime
 	d.currHeight = newHeight
 	d.currHeightTime = time.Now()
 
-	// this may happen when polling
-	if d.currHeight != lastBlockHeight {
-		n := newHeight % int64(cap(d.observedBlockSpeeds))
-		d.observedBlockSpeeds[n] = time.Millisecond * time.Duration(d.currHeightTime.Sub(lastHeightTime).Milliseconds()/(d.currHeight-lastBlockHeight))
-	}
+	n := newHeight % int64(cap(d.observedBlockSpeeds))
+	d.observedBlockSpeeds[n] = time.Millisecond * time.Duration(d.currHeightTime.Sub(lastHeightTime).Milliseconds()/(d.currHeight-lastBlockHeight))
 
 	sum, cnt := 0.0, 0
 	for _, blockSpeed := range d.observedBlockSpeeds {


### PR DESCRIPTION
Previously, the function would unconditionally update the last seen block height value and time, which is not correct if the height scrape interval is lower than block time.

E.g. if `watchers.height-interval` is set to 600ms, and the real block time is 1.5s, then the block duration will be always shown as 600ms.

Updating the block timestamp only when the new block height is different seems to be the correct approach.

---

checked on one of the instances